### PR TITLE
Better support arrow functions in the DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,17 @@ If it's not clear how this might be useful, I'd ask you to consider something li
 
 Properties are another way to solve this problem. In the example above, using properties I only have to setup the mock once. If I want to change what goes into the mock, I only need to override the single property I want to change and that's the value that's used when the mock is created for that section. It also means if I need to alter the mock in the future, I only have to do that in one place. Utility functions can achieve a similar result. I just find it's faster for me to set up with properties.
 
-One technical detail to make note of here is the use of `this`. Properties are accessed at runtime through the use of `this`, which unfortunately precludes the use of arrow functions when you want to refer to properties, since that would bind `this` to the declaration context instead of the runtime context. That is why you see `function` being used to declare functions passed to `it` and `before` blocks above. If you are not referring to `this` in the function body, it is safe to use an arrow function. If you are using `this` to refer to a property, you must use `function`.
+One technical detail to make note of here is the use of `this`. Properties are accessed at runtime through the use of `this`. That is why you see `function` being used to declare functions passed to `it` and `before` blocks above. That won't work with arrow functions. For this reason, the same value is also provided as the only argument to the function.
+
+For example, I could rewrite the first "it" test above as:
+
+```javascript
+it('returns all items', async (test) => {
+  expect(await test.result).to.deep.equal([test.item1, test.item2]);
+});
+```
+
+If you are using `this` to refer to a property in a function body, you must use `function`, not an arrow function. If you wish to use an arrow function, use the function argument instead of `this`. That substitution works for `prop`, `property`, `before`, `after`, and `it`.
 
 <a name="section_test_dsl"></a>
 ## Test DSL
@@ -255,6 +265,10 @@ If you prefer not to pollute the global namespace, you could instead require `ex
 
  * `callback`: **Function** A function to call after each test
 
+   The callback is passed the following arguments:
+
+   * `test`: **TestCase** The test case that ran
+
 **Return Value**
 
 `undefined`
@@ -263,7 +277,7 @@ If you prefer not to pollute the global namespace, you could instead require `ex
 
 Accepts a function to be called after the completion of each test. Note that this is the equivalent of an afterEach function, which is different from other test frameworks.
 
-No arguments are passed to the callback function. The value of `this` is the `TestCase` that ran. The callback may return a Promise.
+The value of `this` is the `TestCase` that ran. The `TestCase` is also passed as a single argument to the function, which is useful if you supply an arrow function. The callback may return a Promise.
 
 `after` may only be called inside of a `describe` or `context` block. If it is called more than once in the same block, the provided functions are called in the order they were supplied.
 
@@ -293,6 +307,10 @@ No arguments are passed to the callback function. The value of `this` is the `Te
 
  * `callback`: **Function** A function to call before each test
 
+   The callback is passed the following arguments:
+
+   * `test`: **TestCase** The test case that is to be run
+
 **Return Value**
 
 `undefined`
@@ -301,7 +319,7 @@ No arguments are passed to the callback function. The value of `this` is the `Te
 
 Accepts a function to be called before each test begins. Note that this is the equivalent of a beforeEach function, which is different from other test frameworks.
 
-No arguments are passed to the callback function. The value of `this` is the `TestCase` that is to be run. The callback may return a Promise.
+The value of `this` is the `TestCase` that is to be run. The `TestCase` is also passed as a single argument to the function, which is useful if you supply an arrow function. The callback may return a Promise.
 
 `before` may only be called inside of a `describe` or `context` block. If it is called more than once in the same block, the provided functions are called in the order they were supplied.
 
@@ -364,6 +382,10 @@ Chai's `expect` function. See [chaijs.com](https://www.chaijs.com) for more info
  * `description`: **String** A description of the expected outcome
  * `testFunction`: **Function** A function which defines the test and performs any assertions
 
+   The `testFunction` receives the following arguments:
+
+   * `test`: **TestCase** The test case being run
+
    If `testFunction` is omitted, it creates a pending test.
 
 **Return Value**
@@ -374,7 +396,7 @@ The created `TestCase`.
 
 Defines a new test or example.
 
-No arguments are passed to `testFunction`. It is invoked when the test is run. The value of `this` is the `TestCase` being run. The function may return a Promise. If it throws an exception or rejects, the test fails. Otherwise, it is considered to have succeeded.
+`testFunction` is invoked when the test is run. The value of `this` is the `TestCase` being run. The `TestCase` is also passed as a single argument to the function, which is useful if you supply an arrow function. The function may return a Promise. If it throws an exception or rejects, the test fails. Otherwise, it is considered to have succeeded.
 
 `it` may only be called inside of a `describe` or `context` block.
 
@@ -399,7 +421,9 @@ No arguments are passed to `testFunction`. It is invoked when the test is run. T
 
 Defines a property available to all tests in the section where the property is defined. Properties are inherited by nested sections and may also be overridden.
 
-The `definition` may be a literal value for the property. If `definition` is a function, it is used as a getter function for the property. A getter function is called with no arguments. The value of `this` in the function is the `TestCase` being run.
+The `definition` may be a literal value for the property. If `definition` is a function, it is used as a getter function for the property.
+
+For a getter function, the value of `this` is the `TestCase` being run. Unlike traditional getter functions, it is passed a single argument, which is also the value of the `TestCase` being run. That is to facilitate the use of arrow functions, where `this` cannot be altered.
 
 By default, getter functions are memoized. That is, after they are invoked the first time time, that return value is used for any subsequent property access (and the getter function is not invoked). Note that getter functions are not invoked until the property is first accessed. In effect, they are lazily evaluated.
 

--- a/lib/test/test-dsl.js
+++ b/lib/test/test-dsl.js
@@ -37,7 +37,7 @@ function describe(what, fn) {
           if (onlyCases && context.isSuite())
             return;
           else
-            return hook.apply(context);
+            return hook.apply(context, [context]);
         }),
         Promise.resolve()
       );
@@ -108,7 +108,7 @@ function _it(expectation, fn, pending) {
 
     description() { return expectation; }
 
-    _test() { return fn.apply(this); }
+    _test() { return fn.apply(this, [this]); }
   })(parentContext());
 
   if (stack.length > 0)
@@ -135,11 +135,17 @@ function parentContext() {
 function memoize(name, fn) {
 
   return function() {
-    const result = fn.apply(this);
+    const result = fn.apply(this, [this]);
 
     Object.defineProperty(this, name, {value: result});
 
     return result;
+  }
+}
+
+function callWithThis(fn) {
+  return function() {
+    return fn.apply(this, [this]);
   }
 }
 
@@ -159,7 +165,7 @@ function property(name, value, opts) {
   if ('function' == typeof value && opts.memoize)
     Object.defineProperty(ctx.prototype, name, {get: memoize(name, value)});
   else if ('function' == typeof value)
-    Object.defineProperty(ctx.prototype, name, {get: value});
+    Object.defineProperty(ctx.prototype, name, {get: callWithThis(value)});
   else
     Object.defineProperty(ctx.prototype, name, {value: value});
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Jeffrey Hunter <jeff@missioncriticallabs.com>",
   "license": "MIT",
   "private": false,
-  "respository": {
+  "repository": {
     "type": "git",
     "url": "https://github.com/jeffreyhunter77/expressive-test.git"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Jeffrey Hunter <jeff@missioncriticallabs.com>",
   "license": "MIT",
   "private": false,
+  "keywords": ["test", "testing", "tdd", "bdd"],
   "repository": {
     "type": "git",
     "url": "https://github.com/jeffreyhunter77/expressive-test.git"

--- a/tests/lib/test/dsl/after-test.js
+++ b/tests/lib/test/dsl/after-test.js
@@ -46,4 +46,19 @@ describe("after()", () => {
 
   });
 
+  context("when calling the function", () => {
+
+    let hook = sinon.stub();
+
+    before(hook);
+
+    it("sets 'this' to the current test", function() {
+      expect(hook).to.have.been.calledOn(this);
+    });
+
+    it("passes the current test as an argument", function() {
+      expect(hook).to.have.been.calledWith(this);
+    });
+
+  });
 });

--- a/tests/lib/test/dsl/before-test.js
+++ b/tests/lib/test/dsl/before-test.js
@@ -42,4 +42,20 @@ describe("before()", () => {
 
   });
 
+  context("when calling the function", () => {
+
+    let hook = newStub();
+
+    before(hook);
+
+    it("sets 'this' to the current test", function() {
+      expect(hook).to.have.been.calledOn(this);
+    });
+
+    it("passes the current test as an argument", function() {
+      expect(hook).to.have.been.calledWith(this);
+    });
+
+  });
+
 });

--- a/tests/lib/test/dsl/it-test.js
+++ b/tests/lib/test/dsl/it-test.js
@@ -32,11 +32,22 @@ describe("it()", () => {
     expect(this.body).to.not.have.been.called;
   });
 
-  it("evaluates the body during the test run", function() {
-    return this.testInstance.run()
-      .then(() => {
-        expect(this.body).to.have.been.calledOnce;
-      });
+  context("when the test is run", function() {
+
+    before(async function() { await this.testInstance.run(); });
+
+    it("evaluates the body", function() {
+      expect(this.body).to.have.been.calledOnce;
+    });
+
+    it("uses the test case instance for 'this'", function() {
+      expect(this.body).to.have.been.calledOn(this.testInstance);
+    });
+
+    it("passes the test case instance", async function() {
+      expect(this.body).to.have.been.calledWith(this.testInstance);
+    });
+
   });
 
   context("without a body", function() {

--- a/tests/lib/test/dsl/property-test.js
+++ b/tests/lib/test/dsl/property-test.js
@@ -52,6 +52,24 @@ describe("property()", () => {
       expect(this.subject).to.equal(this.subject);
     });
 
+    context("when calling the function", () => {
+
+      let getterFunction = sinon.stub();
+
+      property('subject', getterFunction);
+
+      before(function() { this.subject });
+
+      it("sets 'this' to the current test", function() {
+        expect(getterFunction).to.have.been.calledOn(this);
+      });
+
+      it("passes the current test as an argument", function() {
+        expect(getterFunction).to.have.been.calledWith(this);
+      });
+
+    });
+
     context("when the function returns undefined", () => {
 
       let fn = sinon.stub();
@@ -74,6 +92,24 @@ describe("property()", () => {
 
     it("does not memoize the function", function() {
       expect(this.subject).to.not.equal(this.subject);
+    });
+
+    context("when calling the function", () => {
+
+      let getterFunction = sinon.stub();
+
+      property('subject', getterFunction, {memoize: false});
+
+      before(function() { this.subject });
+
+      it("sets 'this' to the current test", function() {
+        expect(getterFunction).to.have.been.calledOn(this);
+      });
+
+      it("passes the current test as an argument", function() {
+        expect(getterFunction).to.have.been.calledWith(this);
+      });
+
     });
 
   });


### PR DESCRIPTION
### Problem

Several parts of the test file DSL require the use of the more verbose `function` syntax because properties are only available on `this`.

### Solution

This change modifies how callbacks are invoked for `after`, `before`, `it`, and `property` (and its alias `prop`). The are now passed a single argument, which is the equivalent of `this`. That allows arrow functions to be used in the same places a traditional `function` would be used if it accepts an argument.

Here's how you would have defined and used a property before:

```javascript
describe("one and one", () => {
  prop("one", 1);
  prop("sum", function() { return this.one + this.one; });

  it("equals two", function() {
    expect(this.sum).to.equal(2);
  });
});
```

Now the same may be written as:

```javascript
describe("one and one", () => {
  prop("one", 1);
  prop("sum", test => test.one + test.one);

  it("equals two", test => expect(test.sum).to.equal(2));
});
```

As a side effect of these changes, `afterAll` and `beforeAll` also pass their callback an argument that is the equivalent of `this` (the containing suite in those cases). A use case for that side effect is not immediately clear, so it is not documented and may not be maintained.

This PR also contains a minor fix for package.json. It fixes the misspelling of repository in the package file and adds some keywords.