### PR TITLE
Add beforeEach and afterEach aliases to before and after

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ When included, this library declares the following globals:
 
  * [after](#dsl_after)
  * [afterAll](#dsl_afterAll)
+ * [afterEach](#dsl_after)
  * [before](#dsl_before)
  * [beforeAll](#dsl_beforeAll)
+ * [beforeEach](#dsl_before)
  * [context](#dsl_describe)
  * [describe](#dsl_describe)
  * [expect](#dsl_expect)
@@ -250,6 +252,10 @@ If you prefer not to pollute the global namespace, you could instead require `ex
 
 <a name="dsl_after"></a>
 ### after(callback)
+
+**Aliases**
+
+ * afterEach
 
 **Parameters**
 
@@ -288,6 +294,10 @@ No arguments are passed to the callback function. The value of `this` is the `Te
 
 <a name="dsl_before"></a>
 ### before(callback)
+
+**Aliases**
+
+ * beforeEach
 
 **Parameters**
 

--- a/init.js
+++ b/init.js
@@ -16,8 +16,10 @@ global.xit = dsl.xit;
 global.property = dsl.property;
 global.prop = dsl.property;
 global.before = dsl.before;
+global.beforeEach = dsl.before;
 global.beforeAll = dsl.beforeAll;
 global.after = dsl.after;
+global.afterEach = dsl.after;
 global.afterAll = dsl.afterAll;
 
 global.expect = chai.expect;

--- a/tests/lib/test/dsl/after-test.js
+++ b/tests/lib/test/dsl/after-test.js
@@ -46,4 +46,8 @@ describe("after()", () => {
 
   });
 
+  it('aliases afterEach to after', () => {
+    expect(afterEach).to.equal(after);
+  });
+
 });

--- a/tests/lib/test/dsl/before-test.js
+++ b/tests/lib/test/dsl/before-test.js
@@ -15,6 +15,10 @@ describe("before()", () => {
 
   before(function() { return this.callback(); });
 
+  it('aliases beforeEach to before', () => {
+    expect(beforeEach).to.equal(before);
+  });
+
   it('is evaluated before tests in the same context', function() {
     expect(this.callback).to.have.been.called;
   });


### PR DESCRIPTION
### Problem

The functions `before()` and `after()` may have ambiguous names for some. They run before each and after each test, respectively. This differs from functions with the same name in other test frameworks.

### Solution

This adds an alias named `beforeEach` for `before` and and alias named `afterEach` for `after`. This doesn't disambiguate before and after. It makes sense to leave their behavior as is given the use of test properties should create a preference for doing work before and after each test instead of the test suite. It does, however, give users the option of disambiguating it in their own test files if they so choose.
